### PR TITLE
fix: 修复首页完整性状态首屏误报受损

### DIFF
--- a/apps/web-dashboard/src/components/Dashboard/MatrixCards.jsx
+++ b/apps/web-dashboard/src/components/Dashboard/MatrixCards.jsx
@@ -12,6 +12,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { getIntegrityStatus } from './integrityStatus';
 
 function cn(...inputs) {
   return twMerge(clsx(inputs));
@@ -49,26 +50,46 @@ export const DashboardCard = ({ children, title, icon: Icon, className, height =
 export const LSIntegrityCard = ({ metrics, provision }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const isHealthy = provision?.ls_core_exists && provision?.cert_pem_exists;
+  const { state, isHealthy } = getIntegrityStatus(provision);
+  const isChecking = state === 'CHECKING';
+  const cardStatusText = isChecking
+    ? t('dashboard.checking')
+    : isHealthy
+      ? t('dashboard.optimal')
+      : t('dashboard.degraded');
   
   return (
     <DashboardCard 
       title={t('dashboard.lsCoreIntegrity')} 
       icon={ShieldCheck}
-      onClick={!isHealthy ? () => navigate('/settings', { state: { tab: 'assets' } }) : undefined}
-      className={!isHealthy ? "border-amber-500/20 hover:border-amber-500/50" : ""}
+      onClick={state === 'DEGRADED' ? () => navigate('/settings', { state: { tab: 'assets' } }) : undefined}
+      className={state === 'DEGRADED' ? "border-amber-500/20 hover:border-amber-500/50" : ""}
     >
       <div className="flex items-baseline gap-2">
-        <span className={isHealthy ? "text-emerald-500 font-black text-3xl tracking-tighter" : "text-amber-500 font-black text-3xl tracking-tighter animate-pulse"}>
-          {isHealthy ? t('dashboard.optimal') : t('dashboard.degraded')}
+        <span className={cn(
+          "font-black text-3xl tracking-tighter",
+          isChecking
+            ? "text-blue-400"
+            : isHealthy
+              ? "text-emerald-500"
+              : "text-amber-500 animate-pulse"
+        )}>
+          {cardStatusText}
         </span>
       </div>
       <div className="mt-2 space-y-1">
         <div className="flex items-center gap-2 text-[10px] text-foreground/40">
-           <div className={cn("w-1.5 h-1.5 rounded-full", isHealthy ? "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.5)]" : "bg-amber-500 shadow-[0_0_10px_rgba(245,158,11,0.5)]")} />
-           {t('dashboard.systemCoreReady')}
+           <div className={cn(
+             "w-1.5 h-1.5 rounded-full",
+             isChecking
+               ? "bg-blue-400 shadow-[0_0_8px_rgba(96,165,250,0.45)]"
+               : isHealthy
+                 ? "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.5)]"
+                 : "bg-amber-500 shadow-[0_0_10px_rgba(245,158,11,0.5)]"
+           )} />
+           {isChecking ? t('dashboard.establishing') : t('dashboard.systemCoreReady')}
         </div>
-        {!isHealthy && (
+        {state === 'DEGRADED' && (
           <div className="text-[9px] text-amber-500/60 font-black uppercase tracking-widest mt-1">
              {t('settings.fixNow')} →
           </div>

--- a/apps/web-dashboard/src/components/Dashboard/integrityStatus.js
+++ b/apps/web-dashboard/src/components/Dashboard/integrityStatus.js
@@ -1,0 +1,20 @@
+export function getIntegrityStatus(provision) {
+  const hasResolvedProvision =
+    provision &&
+    typeof provision.ls_core_exists === 'boolean' &&
+    typeof provision.cert_pem_exists === 'boolean';
+
+  if (!hasResolvedProvision) {
+    return {
+      state: 'CHECKING',
+      isHealthy: null,
+    };
+  }
+
+  const isHealthy = provision.ls_core_exists && provision.cert_pem_exists;
+
+  return {
+    state: isHealthy ? 'OPTIMAL' : 'DEGRADED',
+    isHealthy,
+  };
+}

--- a/apps/web-dashboard/src/components/Dashboard/integrityStatus.test.mjs
+++ b/apps/web-dashboard/src/components/Dashboard/integrityStatus.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getIntegrityStatus } from './integrityStatus.js';
+
+test('returns checking while provision status is still loading', () => {
+  assert.deepEqual(getIntegrityStatus(null), {
+    state: 'CHECKING',
+    isHealthy: null,
+  });
+});
+
+test('returns optimal when both provision flags are present and true', () => {
+  assert.deepEqual(
+    getIntegrityStatus({
+      ls_core_exists: true,
+      cert_pem_exists: true,
+    }),
+    {
+      state: 'OPTIMAL',
+      isHealthy: true,
+    }
+  );
+});
+
+test('returns degraded when any required asset is missing', () => {
+  assert.deepEqual(
+    getIntegrityStatus({
+      ls_core_exists: true,
+      cert_pem_exists: false,
+    }),
+    {
+      state: 'DEGRADED',
+      isHealthy: false,
+    }
+  );
+});

--- a/apps/web-dashboard/src/locales/en.json
+++ b/apps/web-dashboard/src/locales/en.json
@@ -254,6 +254,7 @@
         "memoryMatrix": "Memory Matrix",
         "runtimeHeartbeat": "Runtime Heartbeat",
         "throughputIndex": "Throughput Index",
+        "checking": "CHECKING",
         "optimal": "OPTIMAL",
         "degraded": "DEGRADED",
         "systemCoreReady": "SYSTEM CORE READY",

--- a/apps/web-dashboard/src/locales/zh.json
+++ b/apps/web-dashboard/src/locales/zh.json
@@ -250,6 +250,7 @@
         "memoryMatrix": "内存资源矩阵",
         "runtimeHeartbeat": "运行时心跳监控",
         "throughputIndex": "系统吞吐索引",
+        "checking": "检查中 (CHECKING)",
         "optimal": "极佳 (OPTIMAL)",
         "degraded": "受损 (DEGRADED)",
         "systemCoreReady": "系统核心就绪",


### PR DESCRIPTION
## 变更说明

修复 Dashboard 首页中 `LS 核心完整性` 卡片在页面刷新后的首屏阶段误报 `受损 (DEGRADED)` 的问题。

## 问题原因

当前前端在 `provisionStatus` 尚未加载完成时，会直接执行：

- `provision?.ls_core_exists && provision?.cert_pem_exists`

当 `provision` 还是 `null` 时，这个表达式会得到 `false`，于是页面在首屏阶段先渲染成 `受损`，即使后端真实状态其实是健康的。

这会让用户误以为本地 `ls_core` 或 `cert.pem` 已损坏，但实际上只是健康状态尚未完成初始化。

## 修改内容

- 抽离完整性状态判断逻辑，新增三态：
  - `CHECKING`
  - `OPTIMAL`
  - `DEGRADED`
- 在 `provisionStatus` 未加载完成前，卡片显示 `检查中 (CHECKING)`，不再误报 `受损`
- 仅在明确检测到 `ls_core` 或 `cert.pem` 缺失时，才显示 `受损 (DEGRADED)`
- 补充中英文文案
- 增加一个轻量回归测试，覆盖：
  - 未加载时返回 `CHECKING`
  - 资产齐全时返回 `OPTIMAL`
  - 任一资产缺失时返回 `DEGRADED`

## 影响文件

- `apps/web-dashboard/src/components/Dashboard/MatrixCards.jsx`
- `apps/web-dashboard/src/components/Dashboard/integrityStatus.js`
- `apps/web-dashboard/src/components/Dashboard/integrityStatus.test.mjs`
- `apps/web-dashboard/src/locales/zh.json`
- `apps/web-dashboard/src/locales/en.json`

## 验证结果

已完成以下验证：

- `node --test apps/web-dashboard/src/components/Dashboard/integrityStatus.test.mjs`
- `npm run build`
- 浏览器实测：
  - 页面刚刷新时显示 `检查中 (CHECKING)`
  - 健康状态接口返回后自动切换为 `极佳 (OPTIMAL)`
  - 不再出现首屏误报 `受损 (DEGRADED)`
